### PR TITLE
Describe the latest version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After=network-online.target
 
 [Service]
 ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
+ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/1.0.1/setup-network-environment
 
 ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
 ExecStart=/opt/bin/setup-network-environment


### PR DESCRIPTION
Prior to this change, the example of setup-network-environment service has described v1.0.0 as a version to download. It would be nice to update it to the latest one.